### PR TITLE
Extract setup before docker-compose

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,6 +15,7 @@ elifePipeline {
 
             stage 'Project tests', {
                 try {
+                    sh "./setup.sh"
                     sh "docker-compose up -d --force-recreate"
                     sh "wait_for_port 8075"
                     sh "./project_tests.sh"

--- a/project_tests.sh
+++ b/project_tests.sh
@@ -2,6 +2,4 @@
 
 set -e # everything must succeed.
 
-./setup.sh
-
 ./sciencebeam-convert.sh


### PR DESCRIPTION
Otherwise .temp is created during `docker-compose up`, with root ownership which prevents cleaning it up or modifying it in the future