### PR TITLE
ELPP-3517 Experimental healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,6 @@ RUN echo "cloning ${commit}" && \
 WORKDIR /home/node/texture
 RUN npm install
 
+HEALTHCHECK --interval=10s --timeout=10s --retries=3 CMD curl -v --fail http://localhost:4000
 ARG dependencies_sciencebeam
 LABEL org.elifesciences.dependencies.sciencebeam="${dependencies_sciencebeam}"


### PR DESCRIPTION
This is exposed as State.Health.Status by `docker inspect` and can be used to wait for containers to be up and, well, healthy