### PR TITLE
added del dependency to package.json

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV PROJECT_DIR=${HOME}/sciencebeam-texture
 RUN mkdir ${PROJECT_DIR}
 WORKDIR ${PROJECT_DIR}
 
-COPY --chown=node:node demo/package.json ${PROJECT_DIR}/
+COPY --chown=node:node demo/package.json demo/package-lock.json ${PROJECT_DIR}/
 RUN npm install
 
 COPY --chown=node:node demo ${PROJECT_DIR}/

--- a/demo/package.json
+++ b/demo/package.json
@@ -23,6 +23,7 @@
   "devDependencies": {
     "body-parser": "^1.18.2",
     "browser-sync": "^2.23.6",
+    "del": "^2.2.2",
     "eslint": "^4.19.1",
     "eslint-config-airbnb": "^16.1.0",
     "eslint-config-airbnb-base": "^12.1.0",


### PR DESCRIPTION
Fix for:

```
> sciencebeam-texture-demo@0.0.1 build /home/node/sciencebeam-texture
> gulp build

module.js:545
    throw err;
    ^

Error: Cannot find module 'del'
    at Function.Module._resolveFilename (module.js:543:15)
    at Function.Module._load (module.js:470:25)
    at Module.require (module.js:593:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/home/node/sciencebeam-texture/gulpfile.js:4:13)
    at Module._compile (module.js:649:30)
    at Object.Module._extensions..js (module.js:660:10)
    at Module.load (module.js:561:32)
    at tryModuleLoad (module.js:501:12)
    at Function.Module._load (module.js:493:3)
```

`del` dependency was used in `gulpfile.js` but was not present in `package.json`. It is however present in the `package-lock.json` which highlights another related issue that the lock file isn't currently used / copied to the container.