### PR TITLE
refactor build and downgrade to 8

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,4 @@
 .git
+.temp
+demo/dist
+demo/node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN mkdir ${PROJECT_DIR}
 WORKDIR ${PROJECT_DIR}
 
 COPY --chown=node:node demo/package.json demo/package-lock.json ${PROJECT_DIR}/
-RUN npm install
+RUN npm ci
 
 COPY --chown=node:node demo ${PROJECT_DIR}/
 RUN npm run build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:9.8.0-stretch AS texture
+FROM node:8.16.0-stretch AS texture
 
 USER node
 ENV HOME=/home/node

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,31 @@
+DOCKER_COMPOSE_DEV = docker-compose
+DOCKER_COMPOSE_CI = docker-compose -f docker-compose.yml
+DOCKER_COMPOSE = $(DOCKER_COMPOSE_DEV)
+
+
+build:
+	$(DOCKER_COMPOSE) build
+
+
+build-texture:
+	$(DOCKER_COMPOSE) build texture
+
+
+start-texture: build-texture
+	$(DOCKER_COMPOSE) up -d --no-deps texture
+
+
+start: build
+	$(DOCKER_COMPOSE) up -d
+
+
+stop:
+	$(DOCKER_COMPOSE) down
+
+
+clean:
+	$(DOCKER_COMPOSE) down -v
+
+
+logs:
+	$(DOCKER_COMPOSE) logs -f

--- a/demo/.dockerignore
+++ b/demo/.dockerignore
@@ -1,0 +1,2 @@
+dist
+node_modules

--- a/demo/.env
+++ b/demo/.env
@@ -1,5 +1,5 @@
 COMPOSE_PROJECT_NAME=sciencebeam-texture
 IMAGE_TAG=develop
-UNAME=testuser
+USERNAME=testuser
 UID=1000
 GID=1000

--- a/demo/.env
+++ b/demo/.env
@@ -1,0 +1,5 @@
+COMPOSE_PROJECT_NAME=sciencebeam-texture
+IMAGE_TAG=develop
+UNAME=testuser
+UID=1000
+GID=1000

--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -8,10 +8,10 @@ ENV PROJECT_DIR=${HOME}/sciencebeam-texture
 RUN mkdir ${PROJECT_DIR}
 WORKDIR ${PROJECT_DIR}
 
-COPY --chown=node:node demo/package.json demo/package-lock.json ${PROJECT_DIR}/
+COPY --chown=node:node package.json package-lock.json ${PROJECT_DIR}/
 RUN npm ci
 
-COPY --chown=node:node demo ${PROJECT_DIR}/
+COPY --chown=node:node . ${PROJECT_DIR}/
 RUN npm run build
 
 HEALTHCHECK --interval=10s --timeout=10s --retries=3 CMD curl -v --fail http://localhost:4000

--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -3,15 +3,15 @@ FROM node:8.16.0-stretch AS texture
 USER node
 ENV HOME=/home/node
 
-ENV PROJECT_DIR=${HOME}/sciencebeam-texture
+ENV PROJECT_FOLDER=${HOME}/sciencebeam-texture
 
-RUN mkdir ${PROJECT_DIR}
-WORKDIR ${PROJECT_DIR}
+RUN mkdir ${PROJECT_FOLDER}
+WORKDIR ${PROJECT_FOLDER}
 
-COPY --chown=node:node package.json package-lock.json ${PROJECT_DIR}/
+COPY --chown=node:node package.json package-lock.json ${PROJECT_FOLDER}/
 RUN npm ci
 
-COPY --chown=node:node . ${PROJECT_DIR}/
+COPY --chown=node:node . ${PROJECT_FOLDER}/
 RUN npm run build
 
 HEALTHCHECK --interval=10s --timeout=10s --retries=3 CMD curl -v --fail http://localhost:4000

--- a/demo/Dockerfile.dev
+++ b/demo/Dockerfile.dev
@@ -1,0 +1,14 @@
+FROM node:9.8.0-stretch AS texture
+
+ARG UNAME=testuser
+ARG UID=1000
+ARG GID=1000
+RUN groupadd -g $GID -o $UNAME
+RUN useradd -m -u $UID -g $GID -o -s /bin/bash $UNAME
+
+ENV HOME=/home/dev-user
+RUN mkdir ${HOME} && chown ${UNAME}:${GID} ${HOME}
+USER ${UNAME}
+
+ENV PROJECT_FOLDER=/opt/sciencebeam-texture
+WORKDIR ${PROJECT_FOLDER}

--- a/demo/Dockerfile.dev
+++ b/demo/Dockerfile.dev
@@ -1,14 +1,14 @@
 FROM node:8.16.0-stretch AS texture
 
-ARG UNAME=testuser
+ARG USERNAME=testuser
 ARG UID=1000
 ARG GID=1000
-RUN groupadd -g $GID -o $UNAME
-RUN useradd -m -u $UID -g $GID -o -s /bin/bash $UNAME
+RUN groupadd -g $GID -o $USERNAME
+RUN useradd -m -u $UID -g $GID -o -s /bin/bash $USERNAME
 
 ENV HOME=/home/dev-user
-RUN mkdir ${HOME} && chown ${UNAME}:${GID} ${HOME}
-USER ${UNAME}
+RUN mkdir ${HOME} && chown ${USERNAME}:${GID} ${HOME}
+USER ${USERNAME}
 
 ENV PROJECT_FOLDER=/opt/sciencebeam-texture
 WORKDIR ${PROJECT_FOLDER}

--- a/demo/Dockerfile.dev
+++ b/demo/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:9.8.0-stretch AS texture
+FROM node:8.16.0-stretch AS texture
 
 ARG UNAME=testuser
 ARG UID=1000

--- a/demo/Makefile
+++ b/demo/Makefile
@@ -1,0 +1,39 @@
+UNAME = $(shell whoami)
+UID = $(shell id -u)
+GID = $(shell id -g)
+
+DOCKER_COMPOSE_DEV = docker-compose
+DOCKER_COMPOSE_CI = docker-compose -f docker-compose.yml
+DOCKER_COMPOSE = $(DOCKER_COMPOSE_DEV)
+
+RUN_DEV = $(DOCKER_COMPOSE) run --rm texture-dev
+
+
+show-user:
+	@echo "UNAME=$(UNAME)"
+	@echo "UID=$(UID)"
+	@echo "GID=$(GID)"
+
+
+build-dev:
+	UNAME="$(UNAME)" UID=$(UID) GID=$(GID) $(DOCKER_COMPOSE) build texture-dev
+
+
+shell:
+	$(RUN_DEV) bash
+
+
+clean:
+	$(RUN_DEV) rm -rf node_modules
+
+
+install:
+	$(RUN_DEV) npm install
+
+
+build:
+	$(RUN_DEV) npm run build
+
+
+start:
+	$(RUN_DEV) npm run start

--- a/demo/Makefile
+++ b/demo/Makefile
@@ -19,11 +19,11 @@ build-dev:
 	UNAME="$(UNAME)" UID=$(UID) GID=$(GID) $(DOCKER_COMPOSE) build texture-dev
 
 
-shell:
+shell-dev:
 	$(RUN_DEV) bash
 
 
-clean:
+clean-dev:
 	$(RUN_DEV) rm -rf node_modules
 
 
@@ -35,5 +35,5 @@ bundle:
 	$(RUN_DEV) npm run build
 
 
-start:
+start-dev:
 	$(RUN_DEV) npm run start

--- a/demo/Makefile
+++ b/demo/Makefile
@@ -31,7 +31,7 @@ install:
 	$(RUN_DEV) npm ci
 
 
-build:
+bundle:
 	$(RUN_DEV) npm run build
 
 

--- a/demo/Makefile
+++ b/demo/Makefile
@@ -28,7 +28,7 @@ clean:
 
 
 install:
-	$(RUN_DEV) npm install
+	$(RUN_DEV) npm ci
 
 
 build:

--- a/demo/Makefile
+++ b/demo/Makefile
@@ -1,4 +1,4 @@
-UNAME = $(shell whoami)
+USERNAME = $(shell whoami)
 UID = $(shell id -u)
 GID = $(shell id -g)
 
@@ -10,13 +10,13 @@ RUN_DEV = $(DOCKER_COMPOSE) run --rm texture-dev
 
 
 show-user:
-	@echo "UNAME=$(UNAME)"
+	@echo "USERNAME=$(USERNAME)"
 	@echo "UID=$(UID)"
 	@echo "GID=$(GID)"
 
 
 build-dev:
-	UNAME="$(UNAME)" UID=$(UID) GID=$(GID) $(DOCKER_COMPOSE) build texture-dev
+	USERNAME="$(USERNAME)" UID=$(UID) GID=$(GID) $(DOCKER_COMPOSE) build texture-dev
 
 
 shell-dev:

--- a/demo/docker-compose.override.yml
+++ b/demo/docker-compose.override.yml
@@ -1,0 +1,6 @@
+version: '3'
+
+services:
+    texture-dev:
+        volumes:
+            - .:/opt/sciencebeam-texture

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3'
+
+services:
+    texture-dev:
+        build:
+            context: .
+            dockerfile: Dockerfile.dev
+            args:
+                UNAME: ${UNAME}
+                UID: ${UID}
+                GID: ${GID}
+        image: elifesciences/sciencebeam_texture_dev:${IMAGE_TAG}
+        ports:
+            - "4000:4000"

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -6,7 +6,7 @@ services:
             context: .
             dockerfile: Dockerfile.dev
             args:
-                UNAME: ${UNAME}
+                USERNAME: ${USERNAME}
                 UID: ${UID}
                 GID: ${GID}
         image: elifesciences/sciencebeam_texture_dev:${IMAGE_TAG}

--- a/demo/package.json
+++ b/demo/package.json
@@ -44,11 +44,11 @@
     "postcss-scss": "^1.0.4",
     "stylelint": "^9.1.3",
     "stylelint-order": "^0.8.1",
-    "substance-texture": "^1.0.0-preview.1.1",
     "webpack": "^4.2.0",
     "webpack-cli": "^2.0.12"
   },
   "dependencies": {
+    "substance-texture": "^1.0.0-preview.1.1",
     "npm-install-peers": "^1.2.1"
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
             - texture
     texture:
         build:
-            context: .
+            context: ./demo
             dockerfile: Dockerfile
             args:
                 dependencies_sciencebeam: "${SCIENCEBEAM_TAG}"


### PR DESCRIPTION
This slightly refactors the build... also providing a docker container for development.

It also downgrades node to 8 because node 9 is no longer supported. The latest version of node 8 also includes a newer version of npm, allowing `npm ci` to be used. (Texture mentions in their README to use node 8)

(Doing this mainly to have a more reproducible dev environment, before upgrading Texture)