### PR TITLE
increased nginx proxy timeout to 2m

### DIFF
--- a/config/nginx-default.conf
+++ b/config/nginx-default.conf
@@ -1,7 +1,7 @@
 server {
     listen      80;
     client_max_body_size 50m;
-    proxy_read_timeout 120;
+    proxy_read_timeout 120s;
 
     location /api/ {
         proxy_pass http://sciencebeam:8075/api/;

--- a/config/nginx-default.conf
+++ b/config/nginx-default.conf
@@ -1,6 +1,7 @@
 server {
     listen      80;
     client_max_body_size 50m;
+    proxy_read_timeout 120;
 
     location /api/ {
         proxy_pass http://sciencebeam:8075/api/;


### PR DESCRIPTION
In the absence of a warm-up, this gives the proxy a bit more time.