### PR TITLE
removed deploy on demo jenkins stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,12 +32,4 @@ elifePipeline {
             }
         }
     }
-
-    elifeMainlineOnly {
-        stage 'Deploy on demo', {
-            checkout scm
-            builderDeployRevision 'sciencebeam-texture--demo', commit
-            builderSmokeTests 'sciencebeam-texture--demo', '/home/elife/sciencebeam-texture'
-        }
-    }
 }


### PR DESCRIPTION
disabling deployment via Jenkins.
This is due to migration to Kubernetes (https://github.com/elifesciences/issues/issues/5684) and #43 requiring a deployment change that currently is causing issues. Therefore we won't want #43 deployed on the current demo website.

/cc @tayowonibi (don't think this needs a review)