### PR TITLE
fixed biorxiv sciencebeam api proxy update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,9 @@ docker-compose up
 Effect:
 
 * Starts all the Docker containers.
-* Texture will be available on [port 4000](http://localhost:4000/).
-* [GROBID](grobid.readthedocs.io) will be available on [port 8070](http://localhost:8070/).
+* The demo website will be available on [port 8000](http://localhost:8000/) (via nginx).
+* nginx will forward requests based on the path (e.g. root to texture, `/api` to ScienceBeam)
+* Other ports may also be exposed but are not required
 
 ### Convert Sample PDFs using ScienceBeam Container
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Effect:
 * nginx will forward requests based on the path (e.g. root to texture, `/api` to ScienceBeam)
 * Other ports may also be exposed but are not required
 
+Note: If the ScienceBeam API request fails the first time, this may be due to a timeout while it is loading the models. It may work on subsequent requests.
+
 ### Convert Sample PDFs using ScienceBeam Container
 
 ```bash

--- a/demo/README.md
+++ b/demo/README.md
@@ -4,6 +4,8 @@
 
 ### Using Docker
 
+This method doesn't require a local version of `npm`. It has the advantage of using a consistent version. But the API proxy is currently not supported (i.e. no PDF conversion).
+
 - `make build-dev` to build development image
 - `make npm-ci` to install npm dependencies (as per the lock file)
 - `make bundle` to bundle JavaScript & Co
@@ -13,15 +15,39 @@
 
 `make install-dependency ARGS="--save git+https://git@github.com/substance/texture.git#v1.0"`
 
-### Without Docker
+### Using NPM (Without Docker)
 
 - `npm install` to install dependencies
 - `npm run build` or `gulp build` to build the demo
-- `npm start` or `gulp serve` to serve the demo on `http://localhost:3000` (uses browserSync)
-- `npm run watch` or `gulp watch` watches for and rebuilds based on changes within `src`, it opens a Chrome tab and auto reloads on build.
 
-To run with the demo website with ScienceBeam API proxy (currently only at `/api`):
+#### Start Website (Choose One)
 
-- Start application at the root (via docker-compose)
-- `npm run start-with-api-proxy` to start the server without watching
-- `npm run watch-with-api-proxy` to start the server while watching for changes
+##### Start Website without ScienceBeam API Proxy (No PDF conversion)
+
+- Start site, run either:
+  - `npm start` or `gulp serve` to serve the demo on `http://localhost:3000` (uses browserSync)
+  - `npm run watch` or `gulp watch` watches for and rebuilds based on changes within `src`, it opens a Chrome tab and auto reloads on build.
+
+##### Start Website with ScienceBeam API Proxy to Local ScienceBeam API
+
+- Start application at the [root](../README.md) (via `make start` or docker-compose)
+- build demo site (e.g. `npm install` and `npm run build`, see above)
+- Start site, run either:
+  - `npm run start-with-api-proxy` to start the server without watching
+  - `npm run watch-with-api-proxy` to start the server while watching for changes
+
+##### Start Website with ScienceBeam API Proxy to Live Demo Website ScienceBeam API
+
+This will proxy to the ScienceBeam API on
+[sciencebeam-texture.elifesciences.org](https://sciencebeam-texture.elifesciences.org/).
+
+- Start site, run either:
+  - `npm run start-with-live-api-proxy` to start the server without watching
+  - `npm run watch-with-live-api-proxy` to start the server while watching for changes
+
+#### Demo website ports
+
+After starting the demo website using one of the above methods, it be available on two ports:
+
+- [port 8080](http://localhost:8080) the website won't automcatically refresh but may be working more reliably
+- [port 3000](http://localhost:3000) uses browserSync, some functions may not work but it will try to automatically refresh (assuming you also used the watch command)

--- a/demo/README.md
+++ b/demo/README.md
@@ -36,6 +36,8 @@ This method doesn't require a local version of `npm`. It has the advantage of us
   - `npm run start-with-api-proxy` to start the server without watching
   - `npm run watch-with-api-proxy` to start the server while watching for changes
 
+Note: If the ScienceBeam API request fails the first time, this may be due to a timeout while it is loading the models. It may work on subsequent requests.
+
 ##### Start Website with ScienceBeam API Proxy to Live Demo Website ScienceBeam API
 
 This will proxy to the ScienceBeam API on

--- a/demo/package.json
+++ b/demo/package.json
@@ -7,9 +7,11 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "gulp build",
     "watch": "gulp watch",
-    "watch-with-api-proxy": "PROXY_TO_API_URL=http://localhost:8000/api gulp watch",
+    "watch-with-api-proxy": "PROXY_TO_API_URL=http://localhost:8000/api PROXY_TO_BIORXIV_API_URL=http://localhost:8000/api_biorxiv gulp watch",
+    "watch-with-live-site-api-proxy": "PROXY_TO_API_URL=https://sciencebeam-texture.elifesciences.org/api PROXY_TO_BIORXIV_API_URL=https://sciencebeam-texture.elifesciences.org/api_biorxiv gulp watch",
     "start": "gulp server",
-    "start-with-api-proxy": "PROXY_TO_API_URL=http://localhost:8000/api gulp server",
+    "start-with-api-proxy": "PROXY_TO_API_URL=http://localhost:8000/api  PROXY_TO_BIORXIV_API_URL=http://localhost:8000/api_biorxiv gulp server",
+    "start-with-live-site-api-proxy": "PROXY_TO_API_URL=https://sciencebeam-texture.elifesciences.org/api PROXY_TO_BIORXIV_API_URL=https://sciencebeam-texture.elifesciences.org/api_biorxiv gulp server",
     "start:prod": "NODE_ENV=production DEMO_PORT=4000 gulp server"
   },
   "repository": {


### PR DESCRIPTION
Hopefully the README update will make things more clear.
I also fixed the biorxiv ScienceBeam API proxy. i.e. it should then work for both model types.